### PR TITLE
fix: event-driven LED output + PIO driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ portable-atomic = { version = "1.13.1", features = ["critical-section"] }
 
 # hal drivers
 smart-leds = "0.4.0"
-ws2812-spi = "0.5.1"
+ws2812-pio = { git = "https://github.com/IVAN-MK7/ws2812-pio-rs.git", branch = "hal-0.12" }
 ssd1327-i2c = { git = "https://github.com/pedalboard/ssd1327-i2c", branch = "master" }
 # embedded-hal 1.0.0 needs to be released
 rotary-encoder-embedded = { git = "https://github.com/ost-ing/rotary-encoder-embedded.git", rev = "e042248" }

--- a/src/ledring.rs
+++ b/src/ledring.rs
@@ -8,9 +8,6 @@ pub type LedData = [RGB8; LEDS_PER_RING];
 pub enum Animation {
     On(RGB8),
     Off,
-    Toggle(RGB8, bool),
-    Flash(RGB8),
-    Loudness(f32),
     Fill(RGB8, u8), // color, count (0-12)
 }
 
@@ -27,27 +24,12 @@ impl LedRing {
             animation: Animation::Off,
         }
     }
-    pub fn animate(&mut self) -> LedData {
+
+    /// Render current state to pixel buffer (no side effects).
+    pub fn render(&self) -> LedData {
         match self.animation {
             Animation::On(c) => [c; LEDS_PER_RING],
             Animation::Off => [RGB8::default(); LEDS_PER_RING],
-            Animation::Toggle(c, true) => [c; LEDS_PER_RING],
-            Animation::Toggle(_, false) => [RGB8::default(); LEDS_PER_RING],
-            Animation::Flash(c) => {
-                self.animation = Animation::Off;
-                [c; LEDS_PER_RING]
-            }
-            Animation::Loudness(lufs) => {
-                let mut data = [RGB8::default(); LEDS_PER_RING];
-                for i in 0..LEDS_PER_RING {
-                    let reference = crate::loudness::loudness_step(i);
-                    if lufs >= reference {
-                        data[(self.rotation as usize + LEDS_PER_RING - i) % LEDS_PER_RING] =
-                            crate::loudness::loudness_color(reference);
-                    }
-                }
-                data
-            }
             Animation::Fill(c, count) => {
                 let mut data = [RGB8::default(); LEDS_PER_RING];
                 for i in 0..(count as usize).min(LEDS_PER_RING) {
@@ -59,17 +41,7 @@ impl LedRing {
     }
 
     pub fn set(&mut self, a: Animation) {
-        match a {
-            Animation::Toggle(c, _) => {
-                let current_animation = self.animation;
-                match current_animation {
-                    Animation::Toggle(_, true) => self.animation = Animation::Toggle(c, false),
-                    Animation::Toggle(_, false) => self.animation = Animation::Toggle(c, true),
-                    _ => self.animation = a,
-                };
-            }
-            _ => self.animation = a,
-        }
+        self.animation = a;
     }
 }
 
@@ -85,8 +57,8 @@ mod tests {
 
     #[test]
     fn test_ledring_default_off() {
-        let mut ring = LedRing::default();
-        let data = ring.animate();
+        let ring = LedRing::default();
+        let data = ring.render();
         for led in data.iter() {
             assert_eq!(*led, RGB8::default());
         }
@@ -97,36 +69,22 @@ mod tests {
         let mut ring = LedRing::default();
         let color = RGB8::new(255, 0, 0);
         ring.set(Animation::On(color));
-        let data = ring.animate();
+        let data = ring.render();
         for led in data.iter() {
             assert_eq!(*led, color);
         }
     }
 
     #[test]
-    fn test_ledring_flash_clears() {
+    fn test_ledring_fill() {
         let mut ring = LedRing::default();
         let color = RGB8::new(0, 255, 0);
-        ring.set(Animation::Flash(color));
-
-        let data = ring.animate();
-        assert_eq!(data[0], color);
-
-        let data = ring.animate();
-        assert_eq!(data[0], RGB8::default());
-    }
-
-    #[test]
-    fn test_ledring_toggle() {
-        let mut ring = LedRing::default();
-        let color = RGB8::new(0, 0, 255);
-
-        ring.set(Animation::Toggle(color, false));
-        let data = ring.animate();
-        assert_eq!(data[0], RGB8::default());
-
-        ring.set(Animation::Toggle(color, false));
-        let data = ring.animate();
-        assert_eq!(data[0], color);
+        ring.set(Animation::Fill(color, 3));
+        let data = ring.render();
+        // With rotation=8, filled LEDs are at indices 8, 7, 6
+        assert_eq!(data[8], color);
+        assert_eq!(data[7], color);
+        assert_eq!(data[6], color);
+        assert_eq!(data[5], RGB8::default());
     }
 }

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,5 +1,5 @@
-use crate::ledring::{LedRing, LEDS_PER_RING};
-use colorous::Gradient;
+use crate::ledring::LedRing;
+use crate::ledring::LEDS_PER_RING;
 use smart_leds::RGB8;
 
 const NUM_LEDS: usize = 2;
@@ -28,124 +28,49 @@ pub enum LedRings {
     A,
 }
 
-#[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
-pub enum Animation {
-    On(RGB8),
-    Off,
-    Toggle(RGB8, bool),
-    Flash(RGB8),
-    Rainbow(Gradient),
-}
-
 pub struct Leds {
-    sawtooth: Sawtooth,
-    animations: [Animation; NUM_LEDS],
+    singles: [Option<RGB8>; NUM_LEDS],
     ledrings: [LedRing; NUM_LED_RINGS],
 }
 
 impl Leds {
     pub fn new() -> Self {
         Leds {
-            sawtooth: Sawtooth::new(),
-            animations: [Animation::Off; NUM_LEDS],
+            singles: [None; NUM_LEDS],
             ledrings: [LedRing::default(); NUM_LED_RINGS],
         }
     }
 
-    pub fn animate(&mut self) -> LedData {
+    /// Render current state into a pixel buffer.
+    pub fn render(&self) -> LedData {
         let mut data: LedData = [RGB8::default(); LED_OUTPUTS];
-        self.sawtooth.next();
 
-        for (ring_index, ring) in self.ledrings.iter_mut().enumerate() {
-            for (led_index, ring_led) in ring.animate().into_iter().enumerate() {
-                data[ring_index * LEDS_PER_RING + led_index] = ring_led;
+        for (ring_index, ring) in self.ledrings.iter().enumerate() {
+            for (led_index, pixel) in ring.render().into_iter().enumerate() {
+                data[ring_index * LEDS_PER_RING + led_index] = pixel;
             }
         }
 
-        for (single, a) in self.animations.into_iter().enumerate() {
-            let led = (NUM_LED_RINGS * LEDS_PER_RING) + single;
-            match a {
-                Animation::On(c) => data[led] = c,
-                Animation::Off => data[led] = RGB8::default(),
-                Animation::Toggle(c, true) => data[led] = c,
-                Animation::Toggle(_, false) => data[led] = RGB8::default(),
-                Animation::Flash(c) => {
-                    data[led] = c;
-                    self.animations[single] = Animation::Off
-                }
-                Animation::Rainbow(gradient) => {
-                    let c = gradient.eval_rational(self.sawtooth.value, self.sawtooth.max);
-                    data[led].r = c.r;
-                    data[led].g = c.g;
-                    data[led].b = c.b;
-                }
-            };
+        for (i, color) in self.singles.iter().enumerate() {
+            let led = NUM_LED_RINGS * LEDS_PER_RING + i;
+            data[led] = color.unwrap_or_default();
         }
 
         data
     }
 
-    pub fn set(&mut self, a: Animation, l: Led) {
-        let index = l as usize;
-        match a {
-            Animation::Toggle(c, _) => {
-                let current_animation = self.animations[index];
-                match current_animation {
-                    Animation::Toggle(_, true) => {
-                        self.animations[index] = Animation::Toggle(c, false)
-                    }
-                    Animation::Toggle(_, false) => {
-                        self.animations[index] = Animation::Toggle(c, true)
-                    }
-                    _ => self.animations[index] = a,
-                };
-            }
-            _ => self.animations[index] = a,
-        }
+    pub fn set_single(&mut self, l: Led, color: Option<RGB8>) {
+        self.singles[l as usize] = color;
     }
 
     pub fn set_ledring(&mut self, a: crate::ledring::Animation, r: LedRings) {
-        let ri = r as usize;
-        self.ledrings[ri].set(a)
+        self.ledrings[r as usize].set(a);
     }
 }
 
 impl Default for Leds {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-struct Sawtooth {
-    value: usize,
-    rising: bool,
-    max: usize,
-    min: usize,
-}
-
-impl Sawtooth {
-    fn next(&mut self) -> usize {
-        if self.value == self.max {
-            self.rising = false;
-        }
-        if self.value == self.min {
-            self.rising = true;
-        }
-        if self.rising {
-            self.value += 1
-        } else {
-            self.value -= 1
-        }
-        self.value
-    }
-    fn new() -> Self {
-        Sawtooth {
-            value: 8,
-            rising: true,
-            max: 16,
-            min: 8,
-        }
     }
 }
 
@@ -156,45 +81,29 @@ mod tests {
 
     #[test]
     fn test_leds_default_all_off() {
-        let mut leds = Leds::new();
-        let data = leds.animate();
+        let leds = Leds::new();
+        let data = leds.render();
         for led in data.iter() {
             assert_eq!(*led, RGB8::default());
         }
     }
 
     #[test]
-    fn test_set_led_on() {
+    fn test_set_single_on() {
         let mut leds = Leds::new();
-        leds.set(Animation::On(RED), Led::Mon);
-        let data = leds.animate();
+        leds.set_single(Led::Mon, Some(RED));
+        let data = leds.render();
         let mon_index = NUM_LED_RINGS * LEDS_PER_RING + Led::Mon as usize;
         assert_eq!(data[mon_index], RED);
     }
 
     #[test]
-    fn test_flash_turns_off_after_one_frame() {
+    fn test_set_single_off() {
         let mut leds = Leds::new();
-        leds.set(Animation::Flash(GREEN), Led::Mode);
-        let data = leds.animate();
-        let mode_index = NUM_LED_RINGS * LEDS_PER_RING + Led::Mode as usize;
-        assert_eq!(data[mode_index], GREEN);
-
-        // Next frame should be off
-        let data = leds.animate();
-        assert_eq!(data[mode_index], RGB8::default());
-    }
-
-    #[test]
-    fn test_toggle_flips_state() {
-        let mut leds = Leds::new();
-        leds.set(Animation::Toggle(BLUE, false), Led::Mon);
-        let data = leds.animate();
+        leds.set_single(Led::Mon, Some(RED));
+        leds.set_single(Led::Mon, None);
+        let data = leds.render();
         let mon_index = NUM_LED_RINGS * LEDS_PER_RING + Led::Mon as usize;
         assert_eq!(data[mon_index], RGB8::default());
-
-        leds.set(Animation::Toggle(BLUE, false), Led::Mon);
-        let data = leds.animate();
-        assert_eq!(data[mon_index], BLUE);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ mod app {
     use crate::Mono;
     use core::mem::MaybeUninit;
     use defmt::{debug, error, info, warn};
-    use embedded_hal::{digital::OutputPin, spi::MODE_0};
+    use embedded_hal::digital::OutputPin;
     use embedded_hal_bus::i2c::AtomicDevice;
     use embedded_hal_bus::util::AtomicCell;
     use rtic_sync::channel::{Receiver, Sender, TrySendError};
@@ -48,15 +48,15 @@ mod app {
         fugit::{HertzU32, RateExtU32},
         gpio::{
             bank0::{
-                Gpio0, Gpio1, Gpio10, Gpio11, Gpio12, Gpio14, Gpio16, Gpio17, Gpio18, Gpio19,
+                Gpio0, Gpio1, Gpio10, Gpio11, Gpio16, Gpio17, Gpio18, Gpio19,
                 Gpio2, Gpio20, Gpio21, Gpio24, Gpio25, Gpio3, Gpio4, Gpio5, Gpio6, Gpio7,
             },
-            FunctionI2C, FunctionSio, FunctionSpi, FunctionUart, Pin, Pins, PullDown, PullUp,
+            FunctionI2C, FunctionSio, FunctionUart, Pin, Pins, PullDown, PullUp,
             SioInput, SioOutput,
         },
         i2c::I2C,
         pac::{I2C0, UART0},
-        spi::Spi,
+        pio::PIOExt,
         uart::{DataBits, Reader, StopBits, UartConfig, UartPeripheral, Writer},
         usb::UsbBus,
         Clock, Sio, Watchdog,
@@ -69,7 +69,7 @@ mod app {
     };
     use usbd_midi::{CableNumber, UsbMidiClass, UsbMidiEventPacket, UsbMidiPacketReader};
 
-    use ws2812_spi::Ws2812;
+    use ws2812_pio::Ws2812Direct;
 
     type MidiUartPins = (
         Pin<Gpio0, FunctionUart, PullDown>,
@@ -86,14 +86,10 @@ mod app {
         ),
     >;
 
-    type LedSpi = Spi<
-        rp2040_hal::spi::Enabled,
-        rp2040_hal::pac::SPI1,
-        (
-            Pin<Gpio11, FunctionSpi, PullDown>,
-            Pin<Gpio12, FunctionSpi, PullDown>,
-            Pin<Gpio14, FunctionSpi, PullDown>,
-        ),
+    type LedPio = Ws2812Direct<
+        rp2040_hal::pac::PIO0,
+        rp2040_hal::pio::SM0,
+        Pin<Gpio11, rp2040_hal::gpio::FunctionPio0, PullDown>,
     >;
 
     type DigInPin<P> = Pin<P, FunctionSio<SioInput>, PullUp>;
@@ -124,7 +120,7 @@ mod app {
         uart_midi_out: MidiOut,
         uart_midi_in: MidiIn,
         inputs: InputPins,
-        led_spi: Ws2812<LedSpi>,
+        led_spi: LedPio,
         displays: crate::hmi::display::Displays<
             AtomicDevice<'static, I2CBus>,
             AtomicDevice<'static, I2CBus>,
@@ -241,17 +237,16 @@ mod app {
         let exp = ExpressionPedals::new_direct(adc, exp_a_pin, exp_b_pin);
         let inputs = Inputs::new(vol, gain, buttons, exp);
 
-        // Configure SPI for Ws2812 LEDs
-        let spi_sclk = pins.gpio14.into_function::<FunctionSpi>();
-        let spi_mosi = pins.gpio11.into_function::<FunctionSpi>();
-        let spi_miso = pins.gpio12.into_function::<FunctionSpi>();
-        let spi = Spi::<_, _, _, 8u8>::new(ctx.device.SPI1, (spi_mosi, spi_miso, spi_sclk)).init(
-            &mut resets,
-            &clocks.system_clock,
-            3.MHz(),
-            MODE_0,
+        // Configure PIO for Ws2812 LEDs
+        let led_pin: Pin<Gpio11, rp2040_hal::gpio::FunctionPio0, PullDown> =
+            pins.gpio11.into_function();
+        let (mut pio0, sm0, _, _, _) = ctx.device.PIO0.split(&mut resets);
+        let led_spi = Ws2812Direct::new(
+            led_pin,
+            &mut pio0,
+            sm0,
+            clocks.peripheral_clock.freq(),
         );
-        let led_spi = Ws2812::new(spi);
 
         // Configure I²C for OLED display
         let sda_pin: Pin<_, FunctionI2C, PullUp> = pins.gpio24.reconfigure();

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod app {
     use super::*;
 
     use crate::hmi::inputs::{Buttons, ExpressionPedals, Inputs, Rotary};
+    use pedalboard_midi::leds::LedData;
     use pedalboard_midi::opendeck_handler::{OpenDeck, OpenDeckConfigResponses};
     use crate::Mono;
     use core::mem::MaybeUninit;
@@ -130,10 +131,13 @@ mod app {
         >,
         debug_led: Pin<Gpio10, FunctionSio<SioOutput>, PullDown>,
         sender: Sender<'static, OpenDeckConfigResponses, SYSEX_CAPACITY>,
+        led_sender_midi: Sender<'static, LedData, LED_CAPACITY>,
+        led_sender_usb: Sender<'static, LedData, LED_CAPACITY>,
     }
     const USB_OUT_CAPACITY: usize = 32;
     const SYSEX_CAPACITY: usize = 1;
     const DISPLAY_LOG_CAPACITY: usize = 8;
+    const LED_CAPACITY: usize = 1;
 
     #[init(local = [
         usb_bus: MaybeUninit<usb_device::bus::UsbBusAllocator<UsbBus>> = MaybeUninit::uninit(),
@@ -274,9 +278,11 @@ mod app {
 
         let (display_sender, display_receiver) = make_channel!([u8; 3], DISPLAY_LOG_CAPACITY);
 
+        let (led_sender, led_receiver) = make_channel!(LedData, LED_CAPACITY);
+
         blink::spawn().unwrap();
-        led_animation::spawn().unwrap();
-        poll_input::spawn(usb_sender.clone(), display_sender).unwrap();
+        led_writer::spawn(led_receiver).unwrap();
+        poll_input::spawn(usb_sender.clone(), display_sender, led_sender.clone()).unwrap();
         display_out::spawn(display_receiver).unwrap();
 
         let opendeck = OpenDeck::new(
@@ -305,23 +311,30 @@ mod app {
                 displays,
                 debug_led,
                 sender: sysex_sender,
+                led_sender_midi: led_sender.clone(),
+                led_sender_usb: led_sender,
             },
         )
     }
 
-    #[task(binds = UART0_IRQ, local = [uart_midi_in], shared = [opendeck])]
+    #[task(binds = UART0_IRQ, local = [uart_midi_in, led_sender_midi], shared = [opendeck])]
     fn midi_in(mut ctx: midi_in::Context) {
         use midi2::prelude::*;
 
         match ctx.local.uart_midi_in.read() {
             Ok(m) => {
-                ctx.shared.opendeck.lock(|opendeck| {
+                let led_data = ctx.shared.opendeck.lock(|opendeck| {
                     let mut buf = [0x00u8; 3];
                     m.render_slice(&mut buf);
                     if let Ok(m) = BytesMessage::try_from(&buf[..]) {
-                        opendeck.handle_midi_input(&m);
+                        Some(opendeck.handle_midi_input(&m))
+                    } else {
+                        None
                     }
                 });
+                if let Some(data) = led_data {
+                    ctx.local.led_sender_midi.try_send(data).ok();
+                }
             }
             Err(nb::Error::WouldBlock) => {}
             Err(_) => error!("failed to receive midi message"),
@@ -333,6 +346,7 @@ mod app {
         mut ctx: poll_input::Context,
         mut sender: Sender<'static, UsbMidiEventPacket, USB_OUT_CAPACITY>,
         mut display_sender: Sender<'static, [u8; 3], DISPLAY_LOG_CAPACITY>,
+        mut led_sender: Sender<'static, LedData, LED_CAPACITY>,
     ) {
         let inputs = ctx.local.inputs;
         let uart_midi_out = ctx.local.uart_midi_out;
@@ -359,14 +373,13 @@ mod app {
 
         loop {
             let mut events = heapless::Vec::<_, 14>::new();
-            // Poll encoders at high frequency without yielding
             inputs.poll_encoders(&mut events);
-            // Poll buttons, analog, and encoder buttons at 1ms rate
             let slow_events = inputs.update();
             for e in slow_events.iter() {
                 events.push(*e).ok();
             }
             let mut all_sent: heapless::Vec<[u8; 3], 8> = heapless::Vec::new();
+            let mut led_data: Option<LedData> = None;
             if !events.is_empty() {
                 ctx.shared.opendeck.lock(|opendeck| {
                     for event in events {
@@ -382,11 +395,15 @@ mod app {
                         }
                     }
                     for raw in &all_sent {
-                        opendeck.notify_local_midi(raw);
+                        led_data = Some(opendeck.notify_local_midi(raw));
                     }
                 });
             }
-            // Send outside the lock
+            // Send LED update outside the lock
+            if let Some(data) = led_data {
+                led_sender.try_send(data).ok();
+            }
+            // Send MIDI outside the lock
             for raw in &all_sent {
                 if let Ok(mm) = MidiMessage::try_parse_slice(raw) {
                     uart_midi_out.write(&mm).ok();
@@ -405,7 +422,7 @@ mod app {
     }
 
     #[task(binds = USBCTRL_IRQ, priority = 3,
-        local = [ buf: Vec::<u8, 64>=Vec::new(), sender],
+        local = [ buf: Vec::<u8, 64>=Vec::new(), sender, led_sender_usb],
         shared =[usb_midi,usb_dev,opendeck]
     )]
     fn usb_rx(mut ctx: usb_rx::Context) {
@@ -439,15 +456,14 @@ mod app {
         for packet in buffer_reader.into_iter().flatten() {
             if !packet.is_sysex() {
                 if let Ok(m) = midi2::BytesMessage::try_from(packet.as_raw_bytes()) {
-                    ctx.shared.opendeck.lock(|opendeck| {
-                        opendeck.handle_midi_input(&m);
+                    let led_data = ctx.shared.opendeck.lock(|opendeck| {
+                        opendeck.handle_midi_input(&m)
                     });
+                    ctx.local.led_sender_usb.try_send(led_data).ok();
                 }
                 continue;
             }
 
-            // packet containing a SysEx payload is detected, the data is saved
-            // into a buffer and processed after the message is complete.
             if packet.is_sysex_start() {
                 debug!("SysEx message start");
                 sysex_receive_buffer.clear();
@@ -525,10 +541,6 @@ mod app {
                     }
                 }
             }
-            // Refresh cached colors after SysEx config changes
-            ctx.shared.opendeck.lock(|opendeck| {
-                opendeck.refresh_colors();
-            });
         }
     }
 
@@ -565,18 +577,16 @@ mod app {
         }
     }
 
-    #[task(local = [led_spi], shared =[opendeck])]
-    async fn led_animation(mut ctx: led_animation::Context) {
-        loop {
-            let data = ctx.shared.opendeck.lock(|opendeck| {
-                opendeck.sync_output_leds();
-                opendeck.leds.animate()
-            });
+    #[task(local = [led_spi])]
+    async fn led_writer(
+        ctx: led_writer::Context,
+        mut receiver: Receiver<'static, LedData, LED_CAPACITY>,
+    ) {
+        while let Ok(data) = receiver.recv().await {
             ctx.local
                 .led_spi
                 .write(brightness(data.iter().cloned(), 8))
                 .unwrap();
-            Mono::delay(33.millis()).await;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,8 @@ mod app {
         sender: Sender<'static, OpenDeckConfigResponses, SYSEX_CAPACITY>,
         led_sender_midi: Sender<'static, LedData, LED_CAPACITY>,
         led_sender_usb: Sender<'static, LedData, LED_CAPACITY>,
+        mon_sender_midi: Sender<'static, (), 1>,
+        mon_sender_usb: Sender<'static, (), 1>,
     }
     const USB_OUT_CAPACITY: usize = 32;
     const SYSEX_CAPACITY: usize = 1;
@@ -274,9 +276,11 @@ mod app {
         let (display_sender, display_receiver) = make_channel!([u8; 3], DISPLAY_LOG_CAPACITY);
 
         let (led_sender, led_receiver) = make_channel!(LedData, LED_CAPACITY);
+        let (mon_sender, mon_receiver) = make_channel!((), 1);
 
         blink::spawn().unwrap();
         led_writer::spawn(led_receiver).unwrap();
+        mon_off::spawn(mon_receiver, led_sender.clone()).unwrap();
         poll_input::spawn(usb_sender.clone(), display_sender, led_sender.clone()).unwrap();
         display_out::spawn(display_receiver).unwrap();
 
@@ -308,11 +312,13 @@ mod app {
                 sender: sysex_sender,
                 led_sender_midi: led_sender.clone(),
                 led_sender_usb: led_sender,
+                mon_sender_midi: mon_sender.clone(),
+                mon_sender_usb: mon_sender,
             },
         )
     }
 
-    #[task(binds = UART0_IRQ, local = [uart_midi_in, led_sender_midi], shared = [opendeck])]
+    #[task(binds = UART0_IRQ, local = [uart_midi_in, led_sender_midi, mon_sender_midi], shared = [opendeck])]
     fn midi_in(mut ctx: midi_in::Context) {
         use midi2::prelude::*;
 
@@ -329,6 +335,7 @@ mod app {
                 });
                 if let Some(data) = led_data {
                     ctx.local.led_sender_midi.try_send(data).ok();
+                    ctx.local.mon_sender_midi.try_send(()).ok();
                 }
             }
             Err(nb::Error::WouldBlock) => {}
@@ -417,7 +424,7 @@ mod app {
     }
 
     #[task(binds = USBCTRL_IRQ, priority = 3,
-        local = [ buf: Vec::<u8, 64>=Vec::new(), sender, led_sender_usb],
+        local = [ buf: Vec::<u8, 64>=Vec::new(), sender, led_sender_usb, mon_sender_usb],
         shared =[usb_midi,usb_dev,opendeck]
     )]
     fn usb_rx(mut ctx: usb_rx::Context) {
@@ -455,6 +462,7 @@ mod app {
                         opendeck.handle_midi_input(&m)
                     });
                     ctx.local.led_sender_usb.try_send(led_data).ok();
+                    ctx.local.mon_sender_usb.try_send(()).ok();
                 }
                 continue;
             }
@@ -582,6 +590,21 @@ mod app {
                 .led_spi
                 .write(brightness(data.iter().cloned(), 8))
                 .unwrap();
+        }
+    }
+
+    #[task(shared = [opendeck])]
+    async fn mon_off(
+        mut ctx: mon_off::Context,
+        mut receiver: Receiver<'static, (), 1>,
+        mut led_sender: Sender<'static, LedData, LED_CAPACITY>,
+    ) {
+        while let Ok(()) = receiver.recv().await {
+            Mono::delay(100.millis()).await;
+            // Drain any extra signals that arrived during the delay
+            while receiver.try_recv().is_ok() {}
+            let data = ctx.shared.opendeck.lock(|opendeck| opendeck.clear_mon());
+            led_sender.try_send(data).ok();
         }
     }
 

--- a/src/opendeck_handler.rs
+++ b/src/opendeck_handler.rs
@@ -1,20 +1,21 @@
 use crate::events::{Edge, InputEvent, Pulse};
 use crate::ledring::Animation as RingAnim;
-use crate::leds::{Animation::Flash, Led, LedRings, Leds};
+use crate::leds::{Led, LedData, LedRings, Leds};
 use midi2::BytesMessage;
 use opendeck::button::handler::Action;
 use opendeck::config::SysexResponseIterator;
 use opendeck::encoder::handler::EncoderPulse;
 use opendeck::handler::Messages;
+use opendeck::led::ControlType;
 use smart_leds::colors::*;
+use smart_leds::RGB8;
 
 pub type OpenDeckConfig = opendeck::config::Config<2, 10, 2, 2, 10>;
 pub type OpenDeckConfigResponses = SysexResponseIterator<2, 10, 2, 2, 10>;
 
 pub struct OpenDeck {
     pub config: OpenDeckConfig,
-    pub leds: Leds,
-    colors: [smart_leds::RGB8; 10],
+    leds: Leds,
 }
 
 impl OpenDeck {
@@ -60,7 +61,7 @@ impl OpenDeck {
             ));
         }
 
-        // Set encoder button velocity to 127 (avoid collision with CC values)
+        // Set encoder button velocity to 127
         use opendeck::button::{ButtonSection, ButtonType};
         for i in 0..2u16 {
             config.process_req(OpenDeckRequest::Configuration(
@@ -99,7 +100,7 @@ impl OpenDeck {
         }
 
         // Configure LED outputs for buttons A-C, E (notes 2-4, 6)
-        use opendeck::led::{ControlType, LedSection};
+        use opendeck::led::LedSection;
         use opendeck::ChannelOrAll;
         for (idx, note) in [(0u16, 2u8), (1, 3), (2, 4), (4, 6)] {
             config.process_req(OpenDeckRequest::Configuration(
@@ -143,7 +144,7 @@ impl OpenDeck {
             ));
         }
 
-        // Configure LED outputs 6-7: encoder CC → rings Vol/Gain (LocalCcMultiValue)
+        // Configure LED outputs 6-7: encoder CC → rings Vol/Gain
         for (idx, cc) in [(6u16, 0u8), (7, 1)] {
             config.process_req(OpenDeckRequest::Configuration(
                 Wish::Set,
@@ -162,7 +163,7 @@ impl OpenDeck {
             ));
         }
 
-        // Configure LED outputs 8-9: encoder buttons → single LEDs (LocalNoteSingleValue)
+        // Configure LED outputs 8-9: encoder buttons → single LEDs
         for (idx, note) in [(8u16, 0u8), (9, 1)] {
             config.process_req(OpenDeckRequest::Configuration(
                 Wish::Set,
@@ -186,28 +187,31 @@ impl OpenDeck {
             ));
         }
 
-        // Set LED colors: buttons=Green, encoders/expression=Cyan
+        // Set LED colors
         use opendeck::led::Color;
-        for i in [0u16, 1, 2, 4] { // buttons A,B,C,E
+        for i in [0u16, 1, 2, 4] {
             config.process_req(OpenDeckRequest::Configuration(
-                Wish::Set, Amount::Single,
+                Wish::Set,
+                Amount::Single,
                 Block::Led(i, LedSection::ColorTesting(Color::Green)),
             ));
         }
-        for i in [3u16, 5, 6, 7] { // expression D,F + encoders Vol,Gain
+        for i in [3u16, 5, 6, 7] {
             config.process_req(OpenDeckRequest::Configuration(
-                Wish::Set, Amount::Single,
+                Wish::Set,
+                Amount::Single,
                 Block::Led(i, LedSection::ColorTesting(Color::Cyan)),
             ));
         }
-        for i in [8u16, 9] { // encoder buttons
+        for i in [8u16, 9] {
             config.process_req(OpenDeckRequest::Configuration(
-                Wish::Set, Amount::Single,
+                Wish::Set,
+                Amount::Single,
                 Block::Led(i, LedSection::ColorTesting(Color::Green)),
             ));
         }
 
-        // Reset encoder values to 0 (boot pin glitches may have incremented them)
+        // Reset encoder values to 0
         for i in 0..2u16 {
             config.process_req(OpenDeckRequest::Configuration(
                 Wish::Set,
@@ -219,36 +223,17 @@ impl OpenDeck {
         OpenDeck {
             leds: Leds::default(),
             config,
-            colors: [smart_leds::RGB8::default(); 10],
         }
     }
 
     /// Reset encoder rings to empty after boot glitches settle.
     pub fn reset_encoder_rings(&mut self) {
-        self.refresh_colors();
         self.leds
-            .set_ledring(RingAnim::Fill(smart_leds::RGB8::default(), 0), LedRings::Vol);
+            .set_ledring(RingAnim::Fill(RGB8::default(), 0), LedRings::Vol);
         self.leds
-            .set_ledring(RingAnim::Fill(smart_leds::RGB8::default(), 0), LedRings::Gain);
+            .set_ledring(RingAnim::Fill(RGB8::default(), 0), LedRings::Gain);
     }
 
-    pub fn refresh_colors(&mut self) {
-        use opendeck::led::Color;
-        for i in 0..10 {
-            self.colors[i] = match self.config.output_color(i) {
-                Color::Red => smart_leds::RGB8::new(255, 0, 0),
-                Color::Green => smart_leds::RGB8::new(0, 255, 0),
-                Color::Yellow => smart_leds::RGB8::new(255, 255, 0),
-                Color::Blue => smart_leds::RGB8::new(0, 0, 255),
-                Color::Magenta => smart_leds::RGB8::new(255, 0, 255),
-                Color::Cyan => smart_leds::RGB8::new(0, 255, 255),
-                Color::White => smart_leds::RGB8::new(255, 255, 255),
-                _ => smart_leds::RGB8::new(0, 255, 0),
-            };
-        }
-    }
-
-    /// Cache colors from config (call after boot config).
     pub fn handle_human_input(&mut self, event: InputEvent) -> Messages<'_> {
         match event {
             InputEvent::Vol(pulse) => self.config.handle_encoder(0, pulse.into()),
@@ -266,51 +251,77 @@ impl OpenDeck {
         }
     }
 
-    /// Call after consuming a locally-generated MIDI message to update LED outputs.
-    pub fn notify_local_midi(&mut self, raw: &[u8]) {
-        if raw.len() < 3 {
-            return;
+    /// Process local MIDI and update LED state. Returns rendered LED data.
+    pub fn notify_local_midi(&mut self, raw: &[u8]) -> LedData {
+        if raw.len() >= 3 {
+            let is_cc = (raw[0] & 0xF0) == 0xB0;
+            if let Some((channel, id, value, is_note_on)) = parse_midi_raw(raw) {
+                self.config
+                    .notify_local_midi(channel, id, value, is_note_on, is_cc);
+            }
         }
-        let is_cc = (raw[0] & 0xF0) == 0xB0;
-        if let Some((channel, id, value, is_note_on)) = parse_midi_raw(raw) {
-            self.config.notify_local_midi(channel, id, value, is_note_on, is_cc);
-        }
+        self.update_leds();
+        self.leds.render()
     }
 
-    /// Process an incoming external MIDI message and update LED outputs.
-    pub fn handle_midi_input(&mut self, m: &BytesMessage<&[u8]>) {
-        self.leds.set(Flash(DARK_BLUE), Led::Mon);
+    /// Process an incoming external MIDI message and update LED state. Returns rendered LED data.
+    pub fn handle_midi_input(&mut self, m: &BytesMessage<&[u8]>) -> LedData {
+        // Flash Mon LED on external MIDI
+        self.leds.set_single(Led::Mon, Some(DARK_BLUE));
         if let Some((channel, id, value, is_note_on, is_cc)) = parse_bytes_message(m) {
-            self.config.notify_external_midi(channel, id, value, is_note_on, is_cc);
+            self.config
+                .notify_external_midi(channel, id, value, is_note_on, is_cc);
         }
+        self.update_leds();
+        self.leds.render()
     }
 
     pub fn process_sysex(&mut self, request: &[u8]) -> OpenDeckConfigResponses {
         self.config.process_sysex(request)
     }
 
-    /// Sync opendeck output states to physical LEDs. Call once per animation frame.
-    pub fn sync_output_leds(&mut self) {
-        use crate::leds::Animation;
-        use opendeck::led::ControlType;
+    /// Render current LED state (for use after sysex config changes).
+    pub fn render_leds(&self) -> LedData {
+        self.leds.render()
+    }
 
+    /// Turn off Mon LED (called by flash timeout).
+    pub fn clear_mon(&mut self) -> LedData {
+        self.leds.set_single(Led::Mon, None);
+        self.leds.render()
+    }
+
+    /// Update LED structs from config output state.
+    fn update_leds(&mut self) {
         const RINGS: [LedRings; 8] = [
-            LedRings::A, LedRings::B, LedRings::C, LedRings::D,
-            LedRings::E, LedRings::F, LedRings::Vol, LedRings::Gain,
+            LedRings::A,
+            LedRings::B,
+            LedRings::C,
+            LedRings::D,
+            LedRings::E,
+            LedRings::F,
+            LedRings::Vol,
+            LedRings::Gain,
         ];
         const SINGLE_LEDS: [Led; 2] = [Led::Mode, Led::Mon];
 
-        // Outputs 0-7 → rings
         for i in 0..self.config.output_count().min(8) {
             let ct = self.config.output_control_type(i);
-            let rgb = self.colors[i];
-            let is_multi = matches!(ct,
-                ControlType::LocalCcMultiValue | ControlType::MidiInCcMultiValue |
-                ControlType::LocalNoteMultiValue | ControlType::MidiInNoteMultiValue
+            let rgb = color_to_rgb(self.config.output_color(i));
+            let is_multi = matches!(
+                ct,
+                ControlType::LocalCcMultiValue
+                    | ControlType::MidiInCcMultiValue
+                    | ControlType::LocalNoteMultiValue
+                    | ControlType::MidiInNoteMultiValue
             );
             if is_multi {
                 let level = self.config.output_level(i);
-                let fill = if level <= 12 { level } else { ((level as u16 * 12) / 127) as u8 };
+                let fill = if level <= 12 {
+                    level
+                } else {
+                    ((level as u16 * 12) / 127) as u8
+                };
                 self.leds.set_ledring(RingAnim::Fill(rgb, fill), RINGS[i]);
             } else {
                 let on = self.config.output_state(i);
@@ -320,17 +331,30 @@ impl OpenDeck {
                 );
             }
         }
-        // Outputs 8-9 → single LEDs (always on/off)
+        // Outputs 8-9 → single LEDs
         for i in 0..2 {
             let idx = 8 + i;
             if idx < self.config.output_count() {
                 let on = self.config.output_state(idx);
-                self.leds.set(
-                    if on { Animation::On(self.colors[idx]) } else { Animation::Off },
-                    SINGLE_LEDS[i],
-                );
+                let rgb = color_to_rgb(self.config.output_color(idx));
+                self.leds
+                    .set_single(SINGLE_LEDS[i], if on { Some(rgb) } else { None });
             }
         }
+    }
+}
+
+fn color_to_rgb(c: opendeck::led::Color) -> RGB8 {
+    use opendeck::led::Color;
+    match c {
+        Color::Red => RGB8::new(255, 0, 0),
+        Color::Green => RGB8::new(0, 255, 0),
+        Color::Yellow => RGB8::new(255, 255, 0),
+        Color::Blue => RGB8::new(0, 0, 255),
+        Color::Magenta => RGB8::new(255, 0, 255),
+        Color::Cyan => RGB8::new(0, 255, 255),
+        Color::White => RGB8::new(255, 255, 255),
+        _ => RGB8::new(0, 255, 0),
     }
 }
 
@@ -344,7 +368,7 @@ fn parse_midi_raw(raw: &[u8]) -> Option<(u8, u8, u8, bool)> {
     let value = raw[2];
     match status {
         0x90 if value > 0 => Some((channel, id, value, true)),
-        0x90 => Some((channel, id, value, false)), // velocity 0 = note off
+        0x90 => Some((channel, id, value, false)),
         0x80 => Some((channel, id, value, false)),
         0xB0 => Some((channel, id, value, true)),
         _ => None,
@@ -435,13 +459,12 @@ mod tests {
 
     #[test]
     fn test_notify_local_midi_updates_output() {
-        use opendeck::led::{ControlType, LedSection};
+        use opendeck::led::LedSection;
         use opendeck::ChannelOrAll;
         use opendeck::{Amount, Block, OpenDeckRequest, Wish};
 
         let mut od = test_config();
 
-        // Configure LED output 0: LocalNoteSingleValue, note 60, value 127, channel 1
         od.config.process_req(OpenDeckRequest::Configuration(
             Wish::Set,
             Amount::Single,
@@ -465,13 +488,10 @@ mod tests {
 
         assert!(!od.config.output_state(0));
 
-        // Simulate local Note On: channel 1, note 60, velocity 127
         od.notify_local_midi(&[0x90, 60, 127]);
         assert!(od.config.output_state(0));
 
-        // Simulate local Note Off
         od.notify_local_midi(&[0x80, 60, 0]);
         assert!(!od.config.output_state(0));
     }
-
 }


### PR DESCRIPTION
Fixes #26, fixes #27

## Changes
- Replace 30Hz animation loop with channel-driven writes (SPI only fires on state change)
- Remove color cache, sync_output_leds, refresh_colors, Sawtooth animation
- Switch WS2812 driver from SPI to PIO (immune to interrupt jitter)
- No mutex held during LED output

## Tested
- Flashed on hardware, flicker is gone
- 13 host-side unit tests pass