### PR TITLE
feat: implement MIDI thru routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,7 +913,6 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "opendeck"
 version = "0.1.0"
-source = "git+https://github.com/pedalboard/opendeck?branch=main#612368c7b871173dafb6baad6e387e57cc9978c2"
 dependencies = [
  "heapless 0.9.3",
  "int-enum",
@@ -994,7 +993,7 @@ dependencies = [
  "tinybmp",
  "usb-device",
  "usbd-midi",
- "ws2812-spi",
+ "ws2812-pio",
 ]
 
 [[package]]
@@ -1198,6 +1197,9 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rotary-encoder-embedded"
@@ -1484,7 +1486,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66df34e571fa9993fa6f99131a374d58ca3d694b75f9baac93458fe0d6057bf0"
 dependencies = [
- "smart-leds-trait",
+ "smart-leds-trait 0.3.2",
+]
+
+[[package]]
+name = "smart-leds-trait"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf6d833fa93f16a1c1874e62c2aebe8567e5bdd436d59bf543ed258b6f7a8e3"
+dependencies = [
+ "rgb",
 ]
 
 [[package]]
@@ -1778,13 +1789,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "ws2812-spi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd98e2b649252eced2ec3aa8d5048e7d2ac294276b0567939bbf47741f9934"
+name = "ws2812-pio"
+version = "0.10.0"
+source = "git+https://github.com/IVAN-MK7/ws2812-pio-rs.git?branch=hal-0.12#234d5fae13e88ce38089b9d9a268d352684836f1"
 dependencies = [
- "embedded-hal 1.0.0",
- "smart-leds-trait",
+ "cortex-m",
+ "embedded-hal 0.2.7",
+ "fugit",
+ "nb 1.1.0",
+ "pio",
+ "rp2040-hal",
+ "smart-leds-trait 0.2.1",
+ "smart-leds-trait 0.3.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ tinybmp = "0.7.0"
 
 [patch.crates-io]
 
+[patch."https://github.com/pedalboard/opendeck"]
+opendeck = { path = "../opendeck" }
+
 [dev-dependencies]
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,16 @@ mod app {
         led_sender_usb: Sender<'static, LedData, LED_CAPACITY>,
         mon_sender_midi: Sender<'static, (), 1>,
         mon_sender_usb: Sender<'static, (), 1>,
+        usb_sender_din_thru: Sender<'static, UsbMidiEventPacket, USB_OUT_CAPACITY>,
+        usb_sender_usb_thru: Sender<'static, UsbMidiEventPacket, USB_OUT_CAPACITY>,
+        din_thru_receiver: Receiver<'static, [u8; 3], DIN_THRU_CAPACITY>,
+        din_thru_sender: Sender<'static, [u8; 3], DIN_THRU_CAPACITY>,
     }
     const USB_OUT_CAPACITY: usize = 32;
     const SYSEX_CAPACITY: usize = 1;
     const DISPLAY_LOG_CAPACITY: usize = 8;
     const LED_CAPACITY: usize = 1;
+    const DIN_THRU_CAPACITY: usize = 8;
 
     #[init(local = [
         usb_bus: MaybeUninit<usb_device::bus::UsbBusAllocator<UsbBus>> = MaybeUninit::uninit(),
@@ -277,6 +282,7 @@ mod app {
 
         let (led_sender, led_receiver) = make_channel!(LedData, LED_CAPACITY);
         let (mon_sender, mon_receiver) = make_channel!((), 1);
+        let (din_thru_sender, din_thru_receiver) = make_channel!([u8; 3], DIN_THRU_CAPACITY);
 
         blink::spawn().unwrap();
         led_writer::spawn(led_receiver).unwrap();
@@ -314,28 +320,43 @@ mod app {
                 led_sender_usb: led_sender,
                 mon_sender_midi: mon_sender.clone(),
                 mon_sender_usb: mon_sender,
+                usb_sender_din_thru: usb_sender.clone(),
+                usb_sender_usb_thru: usb_sender.clone(),
+                din_thru_receiver,
+                din_thru_sender,
             },
         )
     }
 
-    #[task(binds = UART0_IRQ, local = [uart_midi_in, led_sender_midi, mon_sender_midi], shared = [opendeck])]
+    #[task(binds = UART0_IRQ, local = [uart_midi_in, led_sender_midi, mon_sender_midi, usb_sender_din_thru], shared = [opendeck])]
     fn midi_in(mut ctx: midi_in::Context) {
         use midi2::prelude::*;
 
         match ctx.local.uart_midi_in.read() {
             Ok(m) => {
-                let led_data = ctx.shared.opendeck.lock(|opendeck| {
+                let (led_data, din_to_usb) = ctx.shared.opendeck.lock(|opendeck| {
                     let mut buf = [0x00u8; 3];
                     m.render_slice(&mut buf);
-                    if let Ok(m) = BytesMessage::try_from(&buf[..]) {
+                    let thru = opendeck.din_to_usb_thru();
+                    let ld = if let Ok(m) = BytesMessage::try_from(&buf[..]) {
                         Some(opendeck.handle_midi_input(&m))
                     } else {
                         None
-                    }
+                    };
+                    (ld, if thru { Some(buf) } else { None })
                 });
                 if let Some(data) = led_data {
                     ctx.local.led_sender_midi.try_send(data).ok();
                     ctx.local.mon_sender_midi.try_send(()).ok();
+                }
+                if let Some(raw) = din_to_usb {
+                    let packet = UsbMidiEventPacket::try_from_payload_bytes(
+                        CableNumber::Cable0,
+                        &raw,
+                    );
+                    if let Ok(packet) = packet {
+                        ctx.local.usb_sender_din_thru.try_send(packet).ok();
+                    }
                 }
             }
             Err(nb::Error::WouldBlock) => {}
@@ -343,7 +364,7 @@ mod app {
         }
     }
 
-    #[task(local = [inputs, uart_midi_out], shared = [opendeck])]
+    #[task(local = [inputs, uart_midi_out, din_thru_receiver], shared = [opendeck])]
     async fn poll_input(
         mut ctx: poll_input::Context,
         mut sender: Sender<'static, UsbMidiEventPacket, USB_OUT_CAPACITY>,
@@ -352,6 +373,7 @@ mod app {
     ) {
         let inputs = ctx.local.inputs;
         let uart_midi_out = ctx.local.uart_midi_out;
+        let din_thru_receiver = ctx.local.din_thru_receiver;
 
         // Skip boot glitches — discard input events for first 200ms
         for _ in 0..200 {
@@ -374,6 +396,13 @@ mod app {
         });
 
         loop {
+            // Drain USB→DIN thru messages
+            while let Ok(raw) = din_thru_receiver.try_recv() {
+                if let Ok(mm) = MidiMessage::try_parse_slice(&raw) {
+                    uart_midi_out.write(&mm).ok();
+                }
+            }
+
             let mut events = heapless::Vec::<_, 14>::new();
             inputs.poll_encoders(&mut events);
             let slow_events = inputs.update();
@@ -382,8 +411,10 @@ mod app {
             }
             let mut all_sent: heapless::Vec<[u8; 3], 8> = heapless::Vec::new();
             let mut led_data: Option<LedData> = None;
+            let mut din_enabled = true;
             if !events.is_empty() {
                 ctx.shared.opendeck.lock(|opendeck| {
+                    din_enabled = opendeck.din_midi_enabled();
                     for event in events {
                         let mut messages = opendeck.handle_human_input(event);
                         let mut buf = [0x00u8; 6];
@@ -407,10 +438,15 @@ mod app {
             }
             // Send MIDI outside the lock
             for raw in &all_sent {
-                if let Ok(mm) = MidiMessage::try_parse_slice(raw) {
-                    uart_midi_out.write(&mm).ok();
-                    display_sender.try_send(*raw).ok();
+                // DIN MIDI out (only if enabled)
+                if din_enabled {
+                    if let Ok(mm) = MidiMessage::try_parse_slice(raw) {
+                        uart_midi_out.write(&mm).ok();
+                    }
                 }
+                // Display log (always for locally-generated messages)
+                display_sender.try_send(*raw).ok();
+                // USB MIDI out (always for locally-generated messages)
                 let packet = UsbMidiEventPacket::try_from_payload_bytes(
                     CableNumber::Cable0,
                     raw,
@@ -424,7 +460,7 @@ mod app {
     }
 
     #[task(binds = USBCTRL_IRQ, priority = 3,
-        local = [ buf: Vec::<u8, 64>=Vec::new(), sender, led_sender_usb, mon_sender_usb],
+        local = [ buf: Vec::<u8, 64>=Vec::new(), sender, led_sender_usb, mon_sender_usb, usb_sender_usb_thru, din_thru_sender],
         shared =[usb_midi,usb_dev,opendeck]
     )]
     fn usb_rx(mut ctx: usb_rx::Context) {
@@ -457,12 +493,28 @@ mod app {
         let buffer_reader = UsbMidiPacketReader::new(&buffer, received_size);
         for packet in buffer_reader.into_iter().flatten() {
             if !packet.is_sysex() {
-                if let Ok(m) = midi2::BytesMessage::try_from(packet.as_raw_bytes()) {
-                    let led_data = ctx.shared.opendeck.lock(|opendeck| {
-                        opendeck.handle_midi_input(&m)
+                if let Ok(m) = midi2::BytesMessage::try_from(packet.payload_bytes()) {
+                    let (led_data, usb_to_din, usb_to_usb) = ctx.shared.opendeck.lock(|opendeck| {
+                        let to_din = opendeck.usb_to_din_thru();
+                        let to_usb = opendeck.usb_to_usb_thru();
+                        let ld = opendeck.handle_midi_input(&m);
+                        (ld, to_din, to_usb)
                     });
                     ctx.local.led_sender_usb.try_send(led_data).ok();
                     ctx.local.mon_sender_usb.try_send(()).ok();
+                    // USB→DIN thru
+                    if usb_to_din {
+                        let raw = packet.payload_bytes();
+                        if raw.len() >= 3 {
+                            let mut arr = [0u8; 3];
+                            arr.copy_from_slice(&raw[..3]);
+                            ctx.local.din_thru_sender.try_send(arr).ok();
+                        }
+                    }
+                    // USB→USB thru
+                    if usb_to_usb {
+                        ctx.local.usb_sender_usb_thru.try_send(packet.clone()).ok();
+                    }
                 }
                 continue;
             }

--- a/src/opendeck_handler.rs
+++ b/src/opendeck_handler.rs
@@ -280,6 +280,26 @@ impl OpenDeck {
         self.config.process_sysex(request)
     }
 
+    /// Whether locally-generated MIDI should be sent on DIN MIDI out.
+    pub fn din_midi_enabled(&self) -> bool {
+        self.config.global_midi().din_midi_enabled()
+    }
+
+    /// Whether incoming DIN MIDI should be forwarded to USB MIDI out.
+    pub fn din_to_usb_thru(&self) -> bool {
+        self.config.global_midi().din_to_usb_thru()
+    }
+
+    /// Whether incoming USB MIDI should be forwarded to DIN MIDI out.
+    pub fn usb_to_din_thru(&self) -> bool {
+        self.config.global_midi().usb_to_din_thru()
+    }
+
+    /// Whether incoming USB MIDI should be forwarded back to USB MIDI out.
+    pub fn usb_to_usb_thru(&self) -> bool {
+        self.config.global_midi().usb_to_usb_thru()
+    }
+
     /// Render current LED state (for use after sysex config changes).
     pub fn render_leds(&self) -> LedData {
         self.leds.render()
@@ -493,5 +513,57 @@ mod tests {
 
         od.notify_local_midi(&[0x80, 60, 0]);
         assert!(!od.config.output_state(0));
+    }
+
+    /// Routing defaults: DIN off, all thru off
+    #[test]
+    fn test_routing_defaults() {
+        let od = test_config();
+        // Per wiki: all routing defaults are 0 (disabled)
+        assert!(!od.din_midi_enabled());
+        assert!(!od.din_to_usb_thru());
+        assert!(!od.usb_to_din_thru());
+        assert!(!od.usb_to_usb_thru());
+    }
+
+    /// Routing can be enabled via SysEx configuration
+    #[test]
+    fn test_routing_enable_via_config() {
+        use opendeck::global::{GlobalSection, MidiIndex};
+        use opendeck::{Amount, Block, OpenDeckRequest, Wish};
+
+        let mut od = test_config();
+
+        // Enable DIN MIDI state
+        od.config.process_req(OpenDeckRequest::Configuration(
+            Wish::Set,
+            Amount::Single,
+            Block::Global(GlobalSection::Midi(MidiIndex::DINMIDIstate, 1)),
+        ));
+        assert!(od.din_midi_enabled());
+
+        // Enable DIN→USB thru
+        od.config.process_req(OpenDeckRequest::Configuration(
+            Wish::Set,
+            Amount::Single,
+            Block::Global(GlobalSection::Midi(MidiIndex::DINtoUSBthru, 1)),
+        ));
+        assert!(od.din_to_usb_thru());
+
+        // Enable USB→DIN thru
+        od.config.process_req(OpenDeckRequest::Configuration(
+            Wish::Set,
+            Amount::Single,
+            Block::Global(GlobalSection::Midi(MidiIndex::USBtoDINthru, 1)),
+        ));
+        assert!(od.usb_to_din_thru());
+
+        // Enable USB→USB thru
+        od.config.process_req(OpenDeckRequest::Configuration(
+            Wish::Set,
+            Amount::Single,
+            Block::Global(GlobalSection::Midi(MidiIndex::USBtoUSBthru, 1)),
+        ));
+        assert!(od.usb_to_usb_thru());
     }
 }


### PR DESCRIPTION
## Summary

Implements MIDI thru routing in firmware, controlled by OpenDeck global MIDI settings via SysEx.

### Routes
- **DIN MIDI state**: locally-generated MIDI only sent to UART when enabled
- **DIN→USB thru**: forward incoming DIN MIDI to USB MIDI out
- **USB→DIN thru**: forward incoming USB MIDI to DIN MIDI out  
- **USB→USB thru**: echo incoming USB MIDI back to USB MIDI out

### Bug fix
Fixed `usb_rx` using `packet.as_raw_bytes()` (includes 4-byte USB-MIDI header) instead of `packet.payload_bytes()` (pure MIDI). This caused `BytesMessage::try_from()` to silently fail for all incoming USB channel voice messages — external MIDI input was never processed for LED state updates.

### Testing
- USB→USB echo verified on hardware (enable setting → Note On echoes back, disable → no echo)
- DIN routing structurally identical, not verified remotely (no DIN receiver connected)

Depends on: pedalboard/opendeck#20