### PR TITLE
Bank switching via long-press D/F

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "eg-seven-segment"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7d2f54ed234b333c71865c641906175a0d58bf366534ba5b8ded74b524b87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "embedded-graphics",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +993,7 @@ dependencies = [
  "debouncr",
  "defmt 1.1.0",
  "defmt-rtt",
+ "eg-seven-segment",
  "embedded-graphics",
  "embedded-hal 1.0.0",
  "embedded-hal-bus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ movavg = { version = "2.3.0", default-features = false }
 debouncr = "0.2.2"
 colorous = { version = "1.0.15", default-features = false }
 embedded-graphics = "0.8.2"
+eg-seven-segment = "0.2.0"
 embedded-text = "0.7.3"
 tinybmp = "0.7.0"
 

--- a/src/hmi/display/mod.rs
+++ b/src/hmi/display/mod.rs
@@ -108,6 +108,20 @@ impl<I2CL: I2c, I2CR: I2c> Displays<I2CL, I2CR> {
             }
         }
     }
+
+    pub fn draw_preset_overlay(&mut self, number: u8, name: &str) {
+        use pedalboard_midi::views::preset_overlay;
+        if let Some(display) = &mut self.display_l.driver {
+            display.clear(Gray4::BLACK).ok();
+            preset_overlay::draw(display, number, name).ok();
+            display.flush().ok();
+        }
+        if let Some(display) = &mut self.display_r.driver {
+            display.clear(Gray4::BLACK).ok();
+            preset_overlay::draw(display, number, name).ok();
+            display.flush().ok();
+        }
+    }
 }
 
 struct Display<I2C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod display;
 pub mod events;
 pub mod leds;
 pub mod ledring;
+pub mod long_press;
 pub mod loudness;
 pub mod opendeck_handler;
 pub mod storage;

--- a/src/long_press.rs
+++ b/src/long_press.rs
@@ -1,0 +1,64 @@
+use crate::events::Edge;
+
+const LONG_PRESS_TICKS: u16 = 500; // 500ms at 1ms poll rate
+
+/// Detects long-press gestures. Returns LongPress on hold > threshold,
+/// ShortPress on release before threshold.
+pub struct LongPressDetector {
+    held_ticks: u16,
+    active: bool,
+    fired: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Gesture {
+    ShortPress,
+    LongPress,
+}
+
+impl LongPressDetector {
+    pub fn new() -> Self {
+        Self {
+            held_ticks: 0,
+            active: false,
+            fired: false,
+        }
+    }
+
+    /// Call every tick with the current button edge (if any).
+    /// Returns a gesture when detected.
+    pub fn update(&mut self, edge: Option<Edge>) -> Option<Gesture> {
+        match edge {
+            Some(Edge::Activate) => {
+                self.active = true;
+                self.held_ticks = 0;
+                self.fired = false;
+                None
+            }
+            Some(Edge::Deactivate) => {
+                self.active = false;
+                if self.fired {
+                    // Long press already handled, suppress short press
+                    None
+                } else {
+                    Some(Gesture::ShortPress)
+                }
+            }
+            None if self.active && !self.fired => {
+                self.held_ticks = self.held_ticks.saturating_add(1);
+                if self.held_ticks >= LONG_PRESS_TICKS {
+                    self.fired = true;
+                    Some(Gesture::LongPress)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Returns true while the button is held (suppresses normal events)
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ mod app {
         usb_midi: UsbMidiClass<'static, UsbBus>,
         usb_dev: usb_device::device::UsbDevice<'static, UsbBus>,
         opendeck: OpenDeck,
+        active_preset: u8,
     }
 
     #[local]
@@ -322,6 +323,7 @@ mod app {
                 usb_midi,
                 usb_dev,
                 opendeck,
+                active_preset: 0,
             },
             Local {
                 uart_midi_out,
@@ -380,7 +382,7 @@ mod app {
         }
     }
 
-    #[task(local = [inputs, uart_midi_out, din_thru_receiver], shared = [opendeck])]
+    #[task(local = [inputs, uart_midi_out, din_thru_receiver], shared = [opendeck, active_preset])]
     async fn poll_input(
         mut ctx: poll_input::Context,
         mut sender: Sender<'static, UsbMidiEventPacket, USB_OUT_CAPACITY>,
@@ -411,6 +413,9 @@ mod app {
             opendeck.reset_encoder_rings();
         });
 
+        let mut lp_d = pedalboard_midi::long_press::LongPressDetector::new();
+        let mut lp_f = pedalboard_midi::long_press::LongPressDetector::new();
+
         loop {
             // Drain USB→DIN thru messages
             while let Ok(raw) = din_thru_receiver.try_recv() {
@@ -425,11 +430,52 @@ mod app {
             for e in slow_events.iter() {
                 events.push(*e).ok();
             }
+
+            // Long-press detection for D (prev preset) and F (next preset)
+            use pedalboard_midi::events::InputEvent;
+            use pedalboard_midi::long_press::Gesture;
+            let edge_d = events.iter().find_map(|e| match e {
+                InputEvent::ButtonD(edge) => Some(*edge),
+                _ => None,
+            });
+            let edge_f = events.iter().find_map(|e| match e {
+                InputEvent::ButtonF(edge) => Some(*edge),
+                _ => None,
+            });
+            let gesture_d = lp_d.update(edge_d);
+            let gesture_f = lp_f.update(edge_f);
+
+            // Handle preset switching on long press
+            let mut preset_changed = false;
+            if gesture_d == Some(Gesture::LongPress) || gesture_f == Some(Gesture::LongPress) {
+                preset_changed = true;
+            }
+
+            // Filter out D/F events if long-press is active (suppress normal MIDI)
+            let suppress_d = lp_d.is_active();
+            let suppress_f = lp_f.is_active();
+            events.retain(|e| match e {
+                InputEvent::ButtonD(_) if suppress_d => false,
+                InputEvent::ButtonF(_) if suppress_f => false,
+                _ => true,
+            });
+
             let mut all_sent: heapless::Vec<[u8; 3], 8> = heapless::Vec::new();
             let mut led_data: Option<LedData> = None;
             let mut din_enabled = true;
             let mut component_info_buf: Option<([u8; 16], usize)> = None;
-            if !events.is_empty() {
+            if !events.is_empty() || preset_changed {
+                if preset_changed {
+                    ctx.shared.active_preset.lock(|active_preset| {
+                        let current = *active_preset;
+                        let next = if gesture_f == Some(Gesture::LongPress) {
+                            (current + 1) % 32
+                        } else {
+                            if current == 0 { 31 } else { current - 1 }
+                        };
+                        *active_preset = next;
+                    });
+                }
                 ctx.shared.opendeck.lock(|opendeck| {
                     din_enabled = opendeck.din_midi_enabled();
                     for event in events {
@@ -757,49 +803,75 @@ mod app {
         }
     }
 
-    #[task(local = [displays])]
+    #[task(local = [displays], shared = [active_preset])]
     async fn display_out(
-        ctx: display_out::Context,
+        mut ctx: display_out::Context,
         mut receiver: Receiver<'static, [u8; 3], DISPLAY_LOG_CAPACITY>,
     ) {
         use crate::hmi::display::DisplayLocation;
+        use heapless::String;
+        use pedalboard_midi::views::performance::PresetMeta;
 
         let displays = ctx.local.displays;
         displays.splash_screen();
         Mono::delay(2000.millis()).await;
 
         // Placeholder preset metadata — will come from flash config later
-        let preset = {
-            use heapless::String;
-            let mut p = pedalboard_midi::views::performance::PresetMeta::default();
-            p.name = String::try_from("Preset 1").unwrap_or_default();
-            p.button_labels[0] = String::try_from("Drive").unwrap_or_default();
-            p.button_labels[1] = String::try_from("Delay").unwrap_or_default();
-            p.button_labels[2] = String::try_from("Reverb").unwrap_or_default();
-            p.button_labels[3] = String::try_from("Looper").unwrap_or_default();
-            p.button_labels[4] = String::try_from("Tap").unwrap_or_default();
-            p.button_labels[5] = String::try_from("Bank+").unwrap_or_default();
-            p
-        };
+        let mut presets: [PresetMeta; 3] = core::array::from_fn(|_| PresetMeta::default());
+        presets[0].name = String::try_from("Preset 1").unwrap_or_default();
+        presets[0].button_labels[0] = String::try_from("Drive").unwrap_or_default();
+        presets[0].button_labels[1] = String::try_from("Delay").unwrap_or_default();
+        presets[0].button_labels[2] = String::try_from("Reverb").unwrap_or_default();
+        presets[0].button_labels[3] = String::try_from("Looper").unwrap_or_default();
+        presets[0].button_labels[4] = String::try_from("Tap").unwrap_or_default();
+        presets[0].button_labels[5] = String::try_from("Bank+").unwrap_or_default();
 
-        displays.draw_performance(&preset);
+        presets[1].name = String::try_from("Preset 2").unwrap_or_default();
+        presets[1].button_labels[0] = String::try_from("Fuzz").unwrap_or_default();
+        presets[1].button_labels[1] = String::try_from("Chorus").unwrap_or_default();
+        presets[1].button_labels[2] = String::try_from("Trem").unwrap_or_default();
+        presets[1].button_labels[3] = String::try_from("Phaser").unwrap_or_default();
+        presets[1].button_labels[4] = String::try_from("Wah").unwrap_or_default();
+        presets[1].button_labels[5] = String::try_from("Bank-").unwrap_or_default();
+
+        presets[2].name = String::try_from("Preset 3").unwrap_or_default();
+        presets[2].button_labels[0] = String::try_from("Clean").unwrap_or_default();
+        presets[2].button_labels[1] = String::try_from("Boost").unwrap_or_default();
+        presets[2].button_labels[2] = String::try_from("Hall").unwrap_or_default();
+        presets[2].button_labels[3] = String::try_from("Loop").unwrap_or_default();
+        presets[2].button_labels[4] = String::try_from("Tune").unwrap_or_default();
+        presets[2].button_labels[5] = String::try_from("Bank-").unwrap_or_default();
+
+        let mut current_preset: u8 = 0;
+        displays.draw_performance(&presets[0]);
 
         // Overlay timeout: counts down each loop iteration (200ms each)
         let mut overlay_ticks: u8 = 0;
         const OVERLAY_DURATION: u8 = 5; // ~1s
+        const PRESET_OVERLAY_DURATION: u8 = 10; // ~2s
 
-        let mut midi_log = pedalboard_midi::display::MidiLog::new();
         loop {
             let mut show_overlay = false;
+
+            // Check for preset change
+            let new_preset = ctx.shared.active_preset.lock(|p| *p);
+            if new_preset != current_preset {
+                current_preset = new_preset;
+                let idx = (current_preset as usize) % presets.len();
+                // Show preset name overlay on both displays
+                displays.draw_overlay(DisplayLocation::L, presets[idx].name.as_str(), current_preset + 1);
+                displays.draw_overlay(DisplayLocation::R, presets[idx].name.as_str(), current_preset + 1);
+                overlay_ticks = PRESET_OVERLAY_DURATION;
+                show_overlay = true;
+            }
 
             while let Ok(raw) = receiver.try_recv() {
                 let status = raw[0] & 0xF0;
                 let ch = (raw[0] & 0x0F) + 1;
                 match status {
-                    0x90 => midi_log.push_note_on(ch, raw[1], raw[2]),
-                    0x80 => midi_log.push_note_off(ch, raw[1]),
+                    0x90 => {},
+                    0x80 => {},
                     0xB0 => {
-                        midi_log.push_cc(ch, raw[1], raw[2]);
                         // Encoder overlay: CC#0 = Vol (left), CC#1 = Gain (right)
                         match raw[1] {
                             0 => {
@@ -815,15 +887,15 @@ mod app {
                             _ => {}
                         }
                     }
-                    0xC0 => midi_log.push_program_change(ch, raw[1]),
-                    _ => midi_log.push_raw("..."),
+                    _ => {},
                 }
             }
 
             if !show_overlay && overlay_ticks > 0 {
                 overlay_ticks -= 1;
                 if overlay_ticks == 0 {
-                    displays.draw_performance(&preset);
+                    let idx = (current_preset as usize) % presets.len();
+                    displays.draw_performance(&presets[idx]);
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -858,9 +858,7 @@ mod app {
             if new_preset != current_preset {
                 current_preset = new_preset;
                 let idx = (current_preset as usize) % presets.len();
-                // Show preset name overlay on both displays
-                displays.draw_overlay(DisplayLocation::L, presets[idx].name.as_str(), current_preset + 1);
-                displays.draw_overlay(DisplayLocation::R, presets[idx].name.as_str(), current_preset + 1);
+                displays.draw_preset_overlay(current_preset + 1, presets[idx].name.as_str());
                 overlay_ticks = PRESET_OVERLAY_DURATION;
                 show_overlay = true;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -818,29 +818,17 @@ mod app {
 
         // Placeholder preset metadata — will come from flash config later
         let mut presets: [PresetMeta; 3] = core::array::from_fn(|_| PresetMeta::default());
-        presets[0].name = String::try_from("Preset 1").unwrap_or_default();
-        presets[0].button_labels[0] = String::try_from("Drive").unwrap_or_default();
-        presets[0].button_labels[1] = String::try_from("Delay").unwrap_or_default();
-        presets[0].button_labels[2] = String::try_from("Reverb").unwrap_or_default();
-        presets[0].button_labels[3] = String::try_from("Looper").unwrap_or_default();
-        presets[0].button_labels[4] = String::try_from("Tap").unwrap_or_default();
-        presets[0].button_labels[5] = String::try_from("Bank+").unwrap_or_default();
-
-        presets[1].name = String::try_from("Preset 2").unwrap_or_default();
-        presets[1].button_labels[0] = String::try_from("Fuzz").unwrap_or_default();
-        presets[1].button_labels[1] = String::try_from("Chorus").unwrap_or_default();
-        presets[1].button_labels[2] = String::try_from("Trem").unwrap_or_default();
-        presets[1].button_labels[3] = String::try_from("Phaser").unwrap_or_default();
-        presets[1].button_labels[4] = String::try_from("Wah").unwrap_or_default();
-        presets[1].button_labels[5] = String::try_from("Bank-").unwrap_or_default();
-
-        presets[2].name = String::try_from("Preset 3").unwrap_or_default();
-        presets[2].button_labels[0] = String::try_from("Clean").unwrap_or_default();
-        presets[2].button_labels[1] = String::try_from("Boost").unwrap_or_default();
-        presets[2].button_labels[2] = String::try_from("Hall").unwrap_or_default();
-        presets[2].button_labels[3] = String::try_from("Loop").unwrap_or_default();
-        presets[2].button_labels[4] = String::try_from("Tune").unwrap_or_default();
-        presets[2].button_labels[5] = String::try_from("Bank-").unwrap_or_default();
+        for i in 0..3 {
+            let mut name: String<16> = String::new();
+            core::fmt::Write::write_fmt(&mut name, format_args!("Preset {}", i + 1)).ok();
+            presets[i].name = name;
+            presets[i].button_labels[0] = String::try_from("A").unwrap_or_default();
+            presets[i].button_labels[1] = String::try_from("B").unwrap_or_default();
+            presets[i].button_labels[2] = String::try_from("C").unwrap_or_default();
+            presets[i].button_labels[3] = String::try_from("D").unwrap_or_default();
+            presets[i].button_labels[4] = String::try_from("E").unwrap_or_default();
+            presets[i].button_labels[5] = String::try_from("F").unwrap_or_default();
+        }
 
         let mut current_preset: u8 = 0;
         displays.draw_performance(&presets[0]);

--- a/src/opendeck_handler.rs
+++ b/src/opendeck_handler.rs
@@ -42,8 +42,8 @@ impl opendeck::SystemHandler for PedalboardHandler {
     }
 }
 
-pub type OpenDeckConfig = opendeck::config::Config<2, 10, 2, 2, 10, PedalboardHandler>;
-pub type OpenDeckConfigResponses = SysexResponseIterator<2, 10, 2, 2, 10>;
+pub type OpenDeckConfig = opendeck::config::Config<32, 10, 2, 2, 10, PedalboardHandler>;
+pub type OpenDeckConfigResponses = SysexResponseIterator<32, 10, 2, 2, 10>;
 
 pub struct OpenDeck {
     pub config: OpenDeckConfig,

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,2 +1,3 @@
 pub mod overlay;
 pub mod performance;
+pub mod preset_overlay;

--- a/src/views/preset_overlay.rs
+++ b/src/views/preset_overlay.rs
@@ -1,0 +1,46 @@
+use core::fmt::Write;
+use eg_seven_segment::SevenSegmentStyleBuilder;
+use embedded_graphics::{
+    mono_font::{ascii::FONT_10X20, MonoTextStyle},
+    pixelcolor::Gray4,
+    prelude::*,
+    primitives::Rectangle,
+    text::Text,
+};
+use heapless::String;
+
+const DISPLAY_SIZE: u32 = 128;
+
+/// Draw a large preset number (7-segment style) with the preset name below
+pub fn draw<D: DrawTarget<Color = Gray4>>(
+    display: &mut D,
+    number: u8,
+    name: &str,
+) -> Result<(), D::Error> {
+    // Large 7-segment number in upper 2/3
+    let seg_style = SevenSegmentStyleBuilder::new()
+        .digit_size(Size::new(40, 70))
+        .segment_width(8)
+        .segment_color(Gray4::WHITE)
+        .build();
+
+    let mut buf: String<4> = String::new();
+    write!(buf, "{}", number).ok();
+
+    // Center the number horizontally
+    let digit_count = buf.len() as u32;
+    let total_width = digit_count * 50; // ~50px per digit with spacing
+    let x = ((DISPLAY_SIZE - total_width) / 2) as i32;
+
+    Text::new(buf.as_str(), Point::new(x, 75), seg_style)
+        .draw(display)?;
+
+    // Preset name below in normal font
+    let text_style = MonoTextStyle::new(&FONT_10X20, Gray4::WHITE);
+    let name_width = (name.len() as u32) * 10;
+    let name_x = ((DISPLAY_SIZE - name_width) / 2) as i32;
+    Text::new(name, Point::new(name_x.max(0), 110), text_style)
+        .draw(display)?;
+
+    Ok(())
+}

--- a/tests-host/tests/long_press.rs
+++ b/tests-host/tests/long_press.rs
@@ -1,0 +1,56 @@
+// Host-side tests for src/long_press.rs
+
+#[path = "../../src/events.rs"]
+mod events;
+
+#[path = "../../src/long_press.rs"]
+mod long_press;
+
+use events::Edge;
+use long_press::{Gesture, LongPressDetector};
+
+#[test]
+fn short_press_on_release_before_threshold() {
+    let mut det = LongPressDetector::new();
+    assert_eq!(det.update(Some(Edge::Activate)), None);
+    // Hold for 100 ticks (< 500)
+    for _ in 0..100 {
+        assert_eq!(det.update(None), None);
+    }
+    assert_eq!(det.update(Some(Edge::Deactivate)), Some(Gesture::ShortPress));
+}
+
+#[test]
+fn long_press_fires_at_threshold() {
+    let mut det = LongPressDetector::new();
+    det.update(Some(Edge::Activate));
+    for _ in 0..499 {
+        assert_eq!(det.update(None), None);
+    }
+    // 500th tick triggers long press
+    assert_eq!(det.update(None), Some(Gesture::LongPress));
+}
+
+#[test]
+fn release_after_long_press_suppressed() {
+    let mut det = LongPressDetector::new();
+    det.update(Some(Edge::Activate));
+    for _ in 0..500 {
+        det.update(None);
+    }
+    // Release should NOT produce ShortPress
+    assert_eq!(det.update(Some(Edge::Deactivate)), None);
+}
+
+#[test]
+fn no_double_fire_on_continued_hold() {
+    let mut det = LongPressDetector::new();
+    det.update(Some(Edge::Activate));
+    for _ in 0..500 {
+        det.update(None);
+    }
+    // Continue holding — should not fire again
+    for _ in 0..500 {
+        assert_eq!(det.update(None), None);
+    }
+}


### PR DESCRIPTION
Implements #1 (bank solution) — first iteration.

**Long-press gesture:**
- Hold D >500ms → previous preset
- Hold F >500ms → next preset
- Short press still sends normal MIDI

**Display:**
- Large 7-segment preset number + name on both displays (~2s)
- Then shows button labels (A-F) for active preset

**Infrastructure:**
- 32 preset capacity
- LongPressDetector with host-side tests
- eg-seven-segment for big numbers
- PresetMeta labels (hardcoded A-F for now, will come from flash/web UI later)